### PR TITLE
fix(helpers): verify_user_token uses remote JWKS with module-level caching

### DIFF
--- a/lib/whop_sdk/client.rb
+++ b/lib/whop_sdk/client.rb
@@ -29,6 +29,18 @@ module WhopSDK
     # @return [String, nil]
     attr_reader :app_id
 
+    # Static public key (PEM or JWK JSON) used by {#verify_user_token} to
+    # verify user tokens. When set, the SDK skips remote JWKS fetching.
+    # Prefer {#user_token_jwks_url} (or the default) so key rotation is
+    # handled automatically.
+    # @return [String, nil]
+    attr_reader :user_token_public_key
+
+    # Override for the JWKS endpoint used by {#verify_user_token}. Defaults
+    # to the canonical Whop endpoint when unset.
+    # @return [String, nil]
+    attr_reader :user_token_jwks_url
+
     # Apps
     # @return [WhopSDK::Resources::Apps]
     attr_reader :apps
@@ -261,6 +273,13 @@ module WhopSDK
     # @param app_id [String, nil] When using the SDK in app mode pass this parameter to allow verifying user
     # tokens Defaults to `ENV["WHOP_APP_ID"]`
     #
+    # @param user_token_public_key [String, nil] Static public key (PEM or JWK JSON) used to verify
+    # user tokens. When set, {#verify_user_token} skips remote JWKS fetching.
+    # Defaults to `ENV["WHOP_USER_TOKEN_PUBLIC_KEY"]`
+    #
+    # @param user_token_jwks_url [String, nil] Override the JWKS URL used by {#verify_user_token}.
+    # Defaults to `ENV["WHOP_USER_TOKEN_JWKS_URL"]`, then to the canonical Whop endpoint.
+    #
     # @param base_url [String, nil] Override the default base URL for the API, e.g.,
     # `"https://api.example.com/v2/"`. Defaults to `ENV["WHOP_BASE_URL"]`
     #
@@ -275,6 +294,8 @@ module WhopSDK
       api_key: ENV["WHOP_API_KEY"],
       webhook_key: ENV["WHOP_WEBHOOK_SECRET"],
       app_id: ENV["WHOP_APP_ID"],
+      user_token_public_key: ENV["WHOP_USER_TOKEN_PUBLIC_KEY"],
+      user_token_jwks_url: ENV["WHOP_USER_TOKEN_JWKS_URL"],
       base_url: ENV["WHOP_BASE_URL"],
       max_retries: self.class::DEFAULT_MAX_RETRIES,
       timeout: self.class::DEFAULT_TIMEOUT_IN_SECONDS,
@@ -293,6 +314,8 @@ module WhopSDK
 
       @api_key = api_key.to_s
       @webhook_key = webhook_key&.to_s
+      @user_token_public_key = user_token_public_key&.to_s
+      @user_token_jwks_url = user_token_jwks_url&.to_s
 
       super(
         base_url: base_url,
@@ -358,29 +381,31 @@ module WhopSDK
       @affiliates = WhopSDK::Resources::Affiliates.new(client: self)
     end
 
-    # Verifies a Whop user token
+    # Verifies a Whop user token.
     #
     # @param token_or_headers [String, Hash, nil] The token string or headers hash
     # @param app_id [String, nil] The app id to verify against
-    # @param public_key [String, nil] Optional custom public key (PEM format)
-    # @param header_name [String, nil] The header name to use (defaults to x-whop-user-token)
-    # @return [UserTokenPayload] The verified token payload
+    # @param public_key [String, nil] Static public key (PEM or JWK JSON). When set, the
+    #   SDK skips remote JWKS fetching. Defaults to the client's `user_token_public_key`.
+    # @param jwks_url [String, nil] Override the JWKS URL. Defaults to the client's
+    #   `user_token_jwks_url`, then to the canonical Whop endpoint.
+    # @param header_name [String, nil] The header name to read the token from
+    # @return [Helpers::VerifyUserToken::UserTokenPayload]
     # @raise [StandardError] If verification fails
     def verify_user_token!(token_or_headers, **opts)
       opts[:app_id] ||= app_id
+      opts[:public_key] = user_token_public_key if opts[:public_key].nil? && user_token_public_key && !user_token_public_key.empty?
+      opts[:jwks_url] = user_token_jwks_url if opts[:jwks_url].nil? && user_token_jwks_url && !user_token_jwks_url.empty?
       unless opts[:app_id]
         raise StandardError, "You must set app_id in the Whop client if you want to verify user tokens"
       end
       Helpers::VerifyUserToken.verify_user_token!(token_or_headers, **opts)
     end
 
-    # Verifies a Whop user token
+    # Verifies a Whop user token. Same signature as {#verify_user_token!}
+    # but returns `nil` on any validation failure instead of raising.
     #
-    # @param token_or_headers [String, Hash, nil] The token string or headers hash
-    # @param app_id [String, nil] The app id to verify against
-    # @param public_key [String, nil] Optional custom public key (PEM format)
-    # @param header_name [String, nil] The header name to use (defaults to x-whop-user-token)
-    # @return [UserTokenPayload, nil] The verified token payload or nil if the verification failed
+    # @return [Helpers::VerifyUserToken::UserTokenPayload, nil]
     def verify_user_token(token_or_headers, **opts)
       verify_user_token!(token_or_headers, **opts)
     rescue StandardError

--- a/lib/whop_sdk/helpers/verify_user_token.rb
+++ b/lib/whop_sdk/helpers/verify_user_token.rb
@@ -1,18 +1,29 @@
 # frozen_string_literal: true
 
 require "jwt"
+require "json"
+require "net/http"
 require "openssl"
+require "uri"
 
 module WhopSDK
   module Helpers
+    # Verifies Whop-issued x-whop-user-token JWTs. By default, fetches the
+    # public signing keys from Whop's canonical JWKS endpoint and caches
+    # them at module scope (TTL-bounded with a cooldown on refetch). The
+    # behavior mirrors the TypeScript SDK's `createRemoteJWKSet` path so
+    # that upgrading to a key rotation doesn't require a gem release.
     module VerifyUserToken
       USER_TOKEN_HEADER_NAME = "x-whop-user-token"
-      USER_TOKEN_VERIFICATION_KEY = <<~PEM
-        -----BEGIN PUBLIC KEY-----
-        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErz8a8vxvexHC0TLT91g7llOdDOsN
-        uYiGEfic4Qhni+HMfRBuUphOh7F3k8QgwZc9UlL0AHmyYqtbhL9NuJes6w==
-        -----END PUBLIC KEY-----
-      PEM
+      DEFAULT_JWKS_URL = "https://api.whop.com/.well-known/jwks.json"
+      TOKEN_ISSUER = "urn:whopcom:exp-proxy"
+      TOKEN_ALGORITHM = "ES256"
+
+      # 12h freshness window before a proactive refresh; 30s cooldown
+      # between refetches when a kid lookup misses. Matches the TS SDK
+      # (`cacheMaxAge: 12 * 60 * 60 * 1000, cooldownDuration: 30_000`).
+      JWKS_CACHE_MAX_AGE_SECONDS = 12 * 60 * 60
+      JWKS_COOLDOWN_SECONDS = 30
 
       # User token payload structure
       class UserTokenPayload
@@ -28,11 +39,84 @@ module WhopSDK
         end
       end
 
-      # Extracts the user token from various input types
+      # Thread-safe, TTL-bounded remote JWKS cache with cooldown-gated
+      # refresh on kid miss.
+      class RemoteJwks
+        def initialize(url, cache_max_age_seconds:, cooldown_seconds:)
+          @url = url
+          @cache_max_age_seconds = cache_max_age_seconds
+          @cooldown_seconds = cooldown_seconds
+          @mutex = Mutex.new
+          @jwk_set = nil
+          @fetched_at = nil
+          @last_refresh_attempt_at = nil
+        end
+
+        # Returns the current JWK::Set, fetching or refreshing as needed.
+        # When `force_refresh` is true, bypass the freshness window but
+        # still honor the refetch cooldown.
+        def jwk_set(force_refresh: false)
+          @mutex.synchronize do
+            now = monotonic_now
+            cache_stale = @jwk_set.nil? || @fetched_at.nil? ||
+                          (now - @fetched_at) > @cache_max_age_seconds
+            cooldown_elapsed = @last_refresh_attempt_at.nil? ||
+                               (now - @last_refresh_attempt_at) > @cooldown_seconds
+
+            refresh_now = @jwk_set.nil? || cache_stale ||
+                          (force_refresh && cooldown_elapsed)
+
+            fetch! if refresh_now
+            @jwk_set
+          end
+        end
+
+        private
+
+        def fetch!
+          @last_refresh_attempt_at = monotonic_now
+          response = Net::HTTP.get_response(URI(@url))
+
+          unless response.is_a?(Net::HTTPSuccess)
+            raise StandardError, "Failed to fetch JWKS from #{@url} (HTTP #{response.code})"
+          end
+
+          parsed = JSON.parse(response.body)
+          @jwk_set = JWT::JWK::Set.new(parsed)
+          @fetched_at = monotonic_now
+        end
+
+        def monotonic_now
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+      end
+
+      # Module-level cache keyed by JWKS URL. One RemoteJwks instance per
+      # distinct URL survives for the process lifetime.
+      @jwks_cache = {}
+      @jwks_cache_mutex = Mutex.new
+
+      # @api private
+      def self.remote_jwks_for(url)
+        @jwks_cache_mutex.synchronize do
+          @jwks_cache[url] ||= RemoteJwks.new(
+            url,
+            cache_max_age_seconds: JWKS_CACHE_MAX_AGE_SECONDS,
+            cooldown_seconds: JWKS_COOLDOWN_SECONDS
+          )
+        end
+      end
+
+      # @api private — test-only hook to clear the module-level cache.
+      def self.reset_jwks_cache!
+        @jwks_cache_mutex.synchronize { @jwks_cache.clear }
+      end
+
+      # Extracts the user token from various input types.
       #
-      # @param token_or_headers [String, Hash, nil] The token string or headers hash
-      # @param header_name [String, nil] The header name to use (defaults to x-whop-user-token)
-      # @return [String, nil] The extracted token or nil
+      # @param token_or_headers [String, Hash, nil] token string or headers hash
+      # @param header_name [String, nil] header name (defaults to x-whop-user-token)
+      # @return [String, nil]
       def self.get_user_token(token_or_headers, header_name: nil)
         header_name ||= USER_TOKEN_HEADER_NAME
 
@@ -46,18 +130,27 @@ module WhopSDK
         end
       end
 
-      # Verifies a Whop user token
+      # Verifies a Whop user token.
       #
-      # @param token_or_headers [String, Hash, nil] The token string or headers hash
-      # @param app_id [String, nil] The app id to verify against
-      # @param public_key [String, nil] Optional custom public key (PEM format)
-      # @param header_name [String, nil] The header name to use (defaults to x-whop-user-token)
-      # @return [UserTokenPayload] The verified token payload
-      # @raise [StandardError] If verification fails
+      # By default fetches the public signing keys from `jwks_url` (or the
+      # canonical Whop endpoint) and caches them at module scope. Pass
+      # `public_key` to verify against a static key instead — useful for
+      # self-hosted / test setups where you know the exact key.
+      #
+      # @param token_or_headers [String, Hash, nil]
+      # @param app_id [String, nil] Required; when set, the aud claim must match.
+      # @param public_key [String, nil] PEM-encoded EC public key or JWK JSON.
+      #   When set, skips remote JWKS fetching entirely.
+      # @param jwks_url [String, nil] Override the JWKS endpoint URL. Defaults
+      #   to {DEFAULT_JWKS_URL}.
+      # @param header_name [String, nil] Header to read the token from.
+      # @return [UserTokenPayload]
+      # @raise [StandardError] on validation failure.
       def self.verify_user_token!(
         token_or_headers,
         app_id: nil,
         public_key: nil,
+        jwks_url: nil,
         header_name: nil
       )
         token_string = get_user_token(token_or_headers, header_name: header_name)
@@ -69,33 +162,72 @@ module WhopSDK
           ERROR
         end
 
-        pem_string = public_key || USER_TOKEN_VERIFICATION_KEY
-        key = OpenSSL::PKey::EC.new(pem_string)
+        payload = if public_key
+          verify_with_static_key(token_string, public_key: public_key)
+        else
+          verify_with_remote_jwks(token_string, jwks_url: jwks_url || DEFAULT_JWKS_URL)
+        end
 
-        # Verify the JWT
-        payload, _header = JWT.decode(
-          token_string,
-          key,
-          true,
-          algorithm: "ES256",
-          iss: "urn:whopcom:exp-proxy",
-          verify_iss: true
-        )
-
-        # Validate required fields
         unless payload["sub"] && payload["aud"] && !payload["aud"].is_a?(Array)
           raise StandardError, "Invalid user token provided to verifyUserToken"
         end
 
-        # Validate app_id if provided
         if app_id && payload["aud"] != app_id
           raise StandardError, "Invalid app id provided to verifyUserToken"
         end
 
-        UserTokenPayload.new(
-          user_id: payload["sub"],
-          app_id: payload["aud"]
+        UserTokenPayload.new(user_id: payload["sub"], app_id: payload["aud"])
+      end
+
+      # @api private
+      def self.verify_with_static_key(token_string, public_key:)
+        key = import_static_key(public_key)
+        decoded_payload, = JWT.decode(
+          token_string,
+          key,
+          true,
+          algorithm: TOKEN_ALGORITHM,
+          iss: TOKEN_ISSUER,
+          verify_iss: true
         )
+        decoded_payload
+      end
+
+      # @api private
+      def self.verify_with_remote_jwks(token_string, jwks_url:)
+        remote = remote_jwks_for(jwks_url)
+
+        # ruby-jwt calls the loader twice when the token's kid isn't found
+        # in the current set — once normally, then again with
+        # invalidate: true. The loader uses that signal to force a
+        # cooldown-guarded refresh, mirroring jose's remote JWKS behavior.
+        jwks_loader = ->(opts) { remote.jwk_set(force_refresh: opts[:invalidate]) }
+
+        decoded_payload, = JWT.decode(
+          token_string,
+          nil,
+          true,
+          algorithms: [TOKEN_ALGORITHM],
+          iss: TOKEN_ISSUER,
+          verify_iss: true,
+          jwks: jwks_loader,
+          # Legacy tokens (pre-kid rollout) have no kid header. Let
+          # ruby-jwt fall back to the first key in the set for those.
+          allow_nil_kid: true
+        )
+        decoded_payload
+      end
+
+      # @api private
+      def self.import_static_key(public_key)
+        stripped = public_key.to_s.strip
+        if stripped.start_with?("-----BEGIN")
+          OpenSSL::PKey::EC.new(stripped)
+        else
+          JWT::JWK.new(JSON.parse(stripped)).verify_key
+        end
+      rescue JSON::ParserError, OpenSSL::PKey::ECError => e
+        raise StandardError, "Invalid public key provided to verifyUserToken: #{e.message}"
       end
     end
   end


### PR DESCRIPTION
## Summary

Mirrors the TypeScript SDK's `createRemoteJWKSet` path so app-proxy key rotations don't require a gem release.

- `Helpers::VerifyUserToken`: removed hardcoded PEM default. Verification now fetches the public keys from Whop's canonical JWKS endpoint (`https://api.whop.com/.well-known/jwks.json`), caches them at module scope with a 12h TTL, and uses a 30s cooldown-guarded refetch when a kid lookup misses. `allow_nil_kid: true` lets legacy pre-kid-rollout tokens still verify during the transition window.
- `public_key` option now accepts either a PEM string (existing) or a JWK JSON string (matches TS), for self-hosted / test setups.
- New `jwks_url` option overrides the default endpoint.
- `Client.rb`: new `user_token_public_key` / `user_token_jwks_url` constructor options (plus `WHOP_USER_TOKEN_PUBLIC_KEY` / `WHOP_USER_TOKEN_JWKS_URL` env fallbacks).

Coordinated with matching changes in the TypeScript and Python SDKs (landing in their respective `next` branches concurrently) so all three ship at the same version.

## Test plan
- [ ] Existing `verify_user_token!` callers still work (backwards-compatible on signatures)
- [x] Remote JWKS fetch path works against the live `api.whop.com` endpoint
- [x] Module-level cache makes subsequent calls ~0ms